### PR TITLE
Fix editable pip install inside docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY setup.py /importer/
 COPY pyproject.toml /importer/
 COPY README.md /importer/
 # --user works too instead of --no-build-isolation
-RUN pip install -v --no-build-isolation -e /importer
+RUN pip install --no-cache-dir -v --no-build-isolation -e /importer
 
 # Copy the unit tests to the image
 COPY tests /importer/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,8 @@ COPY src /importer/src
 COPY setup.py /importer/
 COPY pyproject.toml /importer/
 COPY README.md /importer/
-RUN cd /importer/ && pip install --no-cache-dir -v .
+# --user works too instead of --no-build-isolation
+RUN pip install --no-cache-dir -v --no-build-isolation -e /importer
 
 # Copy the unit tests to the image
 COPY tests /importer/tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ COPY setup.py /importer/
 COPY pyproject.toml /importer/
 COPY README.md /importer/
 # --user works too instead of --no-build-isolation
-RUN pip install --no-cache-dir -v --no-build-isolation -e /importer
+RUN pip install -v --no-build-isolation -e /importer
 
 # Copy the unit tests to the image
 COPY tests /importer/tests


### PR DESCRIPTION
# MaRDI Pull Request

Fix editable pip install inside docker container by adding `--no-build-isolation`.
(Note that `--user` works, too, and might be preferable as the flag is better known, but it also produces more warnings.)


**Instructions for PR review**:
- [x] Conceptual Review (Logic etc...) 
- [x] Code Review (Review your implementation) 
- [x] Checkout (Test changes locally) 

**Checklist for this PR**: 
- [x] [Reviewers and Assignee specified.](https://docs.github.com/en/issues/tracking-your-work-with-issues/assigning-issues-and-pull-requests-to-other-github-users)
- [x] [All related issues are linked.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
