### PR TITLE
strip keywords

### DIFF
--- a/src/mardi_importer/zbmath/ZBMathSource.py
+++ b/src/mardi_importer/zbmath/ZBMathSource.py
@@ -435,6 +435,7 @@ class ZBMathSource(ADataSource):
                     and info_dict["keywords"].strip() != "None"
                 ):
                     keywords = info_dict["keywords"].strip().split(";")
+                    keywords = [x.strip() for x in keywords]
                 else:
                     keywords = None
 


### PR DESCRIPTION
Strip keywords to avoid trailing space error