### PR TITLE
moved local id queries to init instead of repeating

### DIFF
--- a/mardi_importer/mardi_importer/zbmath/ZBMathAuthor.py
+++ b/mardi_importer/mardi_importer/zbmath/ZBMathAuthor.py
@@ -12,9 +12,11 @@ class ZBMathAuthor:
             Author name
         zbmath_author_id:
             zbmath author id
+        label_id_dict:
+            dict mapping labels to ids for frequently searched items and properties
     """
 
-    def __init__(self, integrator, name, zbmath_author_id):
+    def __init__(self, integrator, name, zbmath_author_id, label_id_dict,):
         self.api = integrator
         if name:
             name_parts = name.strip().split(",")
@@ -24,14 +26,15 @@ class ZBMathAuthor:
         self.QID = None
         self.zbmath_author_id = zbmath_author_id.strip()
         self.item = self.init_item()
+        self.label_id_dict = label_id_dict
 
     def init_item(self):
         item = self.api.item.new()
         item.labels.set(language="en", value=self.name)
         # instance of: human
         item.add_claim("wdt:P31", "wd:Q5")
-        profile_prop = self.api.get_local_id_by_label("MaRDI profile type", "property")
-        profile_target = self.api.get_local_id_by_label("MaRDI person profile", "item")[0]
+        profile_prop = self.label_id_dict["mardi_profile_type_prop"]
+        profile_target = self.label_id_dict["mardi_person_profile_item"]
         item.add_claim(profile_prop, profile_target)
         if self.zbmath_author_id:
             # if self.name:

--- a/mardi_importer/mardi_importer/zbmath/ZBMathPublication.py
+++ b/mardi_importer/mardi_importer/zbmath/ZBMathPublication.py
@@ -33,10 +33,8 @@ class ZBMathPublication:
             zbmath de number
         keywords:
             zbmath topic keywords
-        de_number_prop:
-            local property ID of zbmath de number
-        keyword_prop:
-            local property ID of keyword property number
+        label_id_dict:
+            dict mapping labels to ids for frequently searched items and properties
     """
 
     def __init__(
@@ -57,8 +55,7 @@ class ZBMathPublication:
         classifications,
         de_number,
         keywords,
-        de_number_prop,
-        keyword_prop,
+        label_id_dict,
     ):
         self.api = integrator
         self.title = title
@@ -79,8 +76,7 @@ class ZBMathPublication:
         self.classifications = classifications
         self.de_number = de_number
         self.keywords = keywords
-        self.de_number_prop = de_number_prop
-        self.keyword_prop = keyword_prop
+        self.label_id_dict = label_id_dict
         self.item = self.init_item()
 
     def init_item(self):
@@ -130,7 +126,7 @@ class ZBMathPublication:
                 link_claims.append(claim)
             self.item.add_claims(link_claims)
         if self.review_text:
-            prop_nr = self.api.get_local_id_by_label("review text", "property")
+            prop_nr = self.label_id_dict["review_prop"]
             self.item.add_claim(prop_nr, self.review_text)
         if self.reviewer:
             self.item.add_claim("wdt:P4032", self.reviewer)
@@ -141,17 +137,15 @@ class ZBMathPublication:
                 classification_claims.append(claim)
             self.item.add_claims(classification_claims)
         if self.de_number:
-            self.item.add_claim(self.de_number_prop, self.de_number)
+            self.item.add_claim(self.label_id_dict["de_number_prop"], self.de_number)
         if self.keywords:
             kw_claims = []
             for k in self.keywords:
-                claim = self.api.get_claim(self.keyword_prop, k)
+                claim = self.api.get_claim(self.label_id_dict["keyword_prop"], k)
                 kw_claims.append(claim)
             self.item.add_claims(kw_claims)
-        profile_prop = self.api.get_local_id_by_label("MaRDI profile type", "property")
-        profile_target = self.api.get_local_id_by_label(
-            "MaRDI publication profile", "item"
-        )[0]
+        profile_prop = self.label_id_dict["mardi_profile_type_prop"]
+        profile_target = self.label_id_dict["mardi_publication_profile_item"]
         self.item.add_claim(profile_prop, profile_target)
 
     def exists(self):
@@ -168,11 +162,11 @@ class ZBMathPublication:
         # instance of scholarly article
         if self.title:
             self.QID = self.item.is_instance_of_with_property(
-                "wd:Q13442814", self.de_number_prop, self.de_number
+                "wd:Q13442814", self.label_id_dict["de_number_prop"], self.de_number
             )
         else:
             QID_list = self.api.search_entity_by_value(
-                self.de_number_prop, self.de_number
+                self.label_id_dict["de_number_prop"], self.de_number
             )
             # should not be more than one
             self.QID = QID_list[0] if QID_list else None

--- a/mardi_importer/mardi_importer/zbmath/ZBMathSource.py
+++ b/mardi_importer/mardi_importer/zbmath/ZBMathSource.py
@@ -84,12 +84,21 @@ class ZBMathSource(ADataSource):
         filename = self.filepath + "/wikidata_entities.txt"
         self.integrator.import_entities(filename=filename)
         #self.create_local_entities()
-        self.de_number_prop = self.integrator.get_local_id_by_label(
+        self.label_id_dict = {}
+        self.label_id_dict["de_number_prop"] = self.integrator.get_local_id_by_label( #de_number_prop
             "zbMATH DE Number", "property"
         )
-        self.keyword_prop = self.integrator.get_local_id_by_label(
+        self.label_id_dict["keyword_prop"] = self.integrator.get_local_id_by_label( #keyword_prop
             "zbMATH Keywords", "property"
         )
+        self.label_id_dict["review_prop"] = self.api.get_local_id_by_label("review text", "property")
+        self.label_id_dict["mardi_profile_type_prop"] = self.api.get_local_id_by_label("MaRDI profile type", "property")
+        self.label_id_dict["mardi_publication_profile_item"] = self.api.get_local_id_by_label(
+            "MaRDI publication profile", "item"
+        )[0]
+        self.label_id_dict["mardi_person_profile_item"] = self.api.get_local_id_by_label("MaRDI person profile", "item")[0]
+
+
 
     def create_local_entities(self):
         filename = self.filepath + "/new_entities.json"
@@ -626,6 +635,7 @@ class ZBMathSource(ADataSource):
                                         integrator=self.integrator,
                                         name=reviewer_name,
                                         zbmath_author_id=reviewer_id,
+                                        label_id_dict = self.label_id_dict,
                                     )
                                     reviewer = reviewer_object.create()
                                 except Exception as e:
@@ -687,8 +697,7 @@ class ZBMathSource(ADataSource):
                             classifications=classifications,
                             de_number=de_number,
                             keywords=keywords,
-                            de_number_prop=self.de_number_prop,
-                            keyword_prop=self.keyword_prop,
+                            label_id_dict = self.label_id_dict,
                         )
                         if publication.exists():
                             print(f"Publication {document_title} exists")


### PR DESCRIPTION
I moved properties and item ids that were queried for every time a publication or author was created into the init method of the source file
