### PR TITLE
catch attribute error

### DIFF
--- a/mardi_importer/mardi_importer/arxiv/ArxivPublication.py
+++ b/mardi_importer/mardi_importer/arxiv/ArxivPublication.py
@@ -155,10 +155,13 @@ class Arxiv():
             }
 
             base_url = "https://arxiv.org/a/"
-            req = requests.get(base_url + arxiv_author_id + ".html", headers)
+            req = requests.get(base_url + arxiv_author_id + ".html", headers=headers)
             soup = BeautifulSoup(req.content, 'html.parser')
 
-            author_html = soup.find("div", id="content").find("h1").get_text()
+            try:
+                author_html = soup.find("div", id="content").find("h1").get_text(strip=True)
+            except AttributeError:
+                author_html = "Not Found"
             if author_html == "Not Found":
                 finish = True
             else:


### PR DESCRIPTION
Sometimes, the author search returns a different failure page that does not contain h1. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of the arxiv author identification system by implementing graceful handling of missing or malformed data structures, preventing unexpected crashes when expected elements are unavailable.
  * Improved error recovery mechanisms in author information retrieval to ensure more robust and reliable operation even when encountering incomplete or unexpected data formats in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->