### PR TITLE
make table time function more flexible and increase to 72 hours

### DIFF
--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -12,7 +12,7 @@ from services.import_service import (
     DEFAULT_WORKFLOW_NAME,
     build_health_payload,
     get_workflow_result,
-    get_workflow_runs_last_24_hours,
+    get_workflow_runs_last_n_hours,
     get_workflow_status,
     import_cran_sync,
     import_doi_sync,
@@ -198,9 +198,10 @@ def cmd_import_workflow_runs(_args: argparse.Namespace) -> int:
     log.info("Fetching workflow runs from the last 24 hours.")
 
     try:
-        result = get_workflow_runs_last_24_hours(
+        result = get_workflow_runs_last_n_hours(
             PREFECT_API_URL,
             PREFECT_API_AUTH_STRING,
+            72
         )
         print(json.dumps(result))
         return 0

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -8,7 +8,7 @@ from services.import_service import (
     DEFAULT_WORKFLOW_NAME,
     build_health_payload,
     get_workflow_result,
-    get_workflow_runs_last_24_hours,
+    get_workflow_runs_last_n_hours,
     get_workflow_status,
     import_cran_sync,
     import_doi_sync,
@@ -167,9 +167,10 @@ def import_workflow_runs():
     log.info("Called 'import_workflow_runs'.")
 
     try:
-        result = get_workflow_runs_last_24_hours(
+        result = get_workflow_runs_last_n_hours(
             PREFECT_API_URL,
             PREFECT_API_AUTH_STRING,
+            72
         )
         return jsonify(result), 200
     except requests.HTTPError as exc:

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -206,17 +206,18 @@ def get_workflow_result(
     )
 
 
-def get_workflow_runs_last_24_hours(
+def get_workflow_runs_last_n_hours(
     prefect_api_url: str,
     prefect_api_auth_string: str | None,
+    hours: int,
 ) -> list[dict]:
     """
-    Fetch Prefect flow runs from the last 24 hours (excluding SCHEDULED).
+    Fetch Prefect flow runs from the last n hours (excluding SCHEDULED).
     Works with Prefect Server/OSS REST API (/api/flow_runs/filter).
     """
-    log.info("Fetching workflow runs from the last 24 hours.")
+    log.info(f"Fetching workflow runs from the last {hours} hours.")
 
-    since = datetime.now(timezone.utc) - timedelta(hours=24)
+    since = datetime.now(timezone.utc) - timedelta(hours=hours)
     since_str = since.isoformat().replace("+00:00", "Z")
 
     url = prefect_api_url.rstrip("/") + "/flow_runs/filter"


### PR DESCRIPTION
make table time function more flexible and increase to 72 hours

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extended the workflow runs import window from the last 24 hours to the last 72 hours, enabling retrieval of more historical workflow run data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->