### PR TITLE
Fix typo in classification variable name

### DIFF
--- a/mardi_importer/mardi_importer/zbmath/ZBMathSource.py
+++ b/mardi_importer/mardi_importer/zbmath/ZBMathSource.py
@@ -760,7 +760,7 @@ class ZBMathSource(ADataSource):
                                         changed = True
                                 #add msc if they are not already there
                                 if not 'P226' in arxiv_item.claims.get_json().keys():
-                                    if publication.classfications:
+                                    if publication.classifications:
                                         classification_claims = []
                                         for c in publication.classifications:
                                             claim = self.api.get_claim("P226", c)


### PR DESCRIPTION
fix typo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo that prevented proper enrichment of arXiv item classifications. Classification claims are now correctly added to arXiv items during the import process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->