### PR TITLE
Add create-item CLI command and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently the following sources are supported:
 * crossref
 * Zenodo
 * ORCID
+* JSON-defined knowledge graph items
 
 ## Documentation
 

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -11,6 +11,8 @@ from wikibaseintegrator.wbi_login import LoginError
 from services.import_service import (
     DEFAULT_WORKFLOW_NAME,
     build_health_payload,
+    create_item_sync,
+    create_typed_item_sync,
     get_workflow_result,
     get_workflow_runs_last_n_hours,
     get_workflow_status,
@@ -21,6 +23,7 @@ from services.import_service import (
     trigger_doi_async,
     trigger_wikidata_async,
 )
+from services.item_schemas import KNOWN_TYPES
 from services.version import get_version
 
 logging.basicConfig(
@@ -312,6 +315,41 @@ def cmd_import_cran(args: argparse.Namespace) -> int:
     return 0 if all_ok else 1
 
 
+def cmd_create_item(args: argparse.Namespace) -> int:
+    """Create a Wikibase item from a typed schema or raw label/claims.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Process exit code.
+    """
+    if args.type:
+        fields: dict = {}
+        if args.fields:
+            try:
+                fields = json.loads(args.fields)
+            except json.JSONDecodeError as exc:
+                print(json.dumps({"error": f"invalid JSON in --fields: {exc}"}))
+                return 2
+        payload, ok = create_typed_item_sync(args.type, fields)
+    else:
+        if not args.label:
+            print(json.dumps({"error": "either --type or --label is required"}))
+            return 2
+        claims: dict = {}
+        if args.claims:
+            try:
+                claims = json.loads(args.claims)
+            except json.JSONDecodeError as exc:
+                print(json.dumps({"error": f"invalid JSON in --claims: {exc}"}))
+                return 2
+        payload, ok = create_item_sync(args.label, args.description, claims)
+
+    print(json.dumps(payload))
+    return 0 if ok else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser.
 
@@ -379,6 +417,29 @@ def build_parser() -> argparse.ArgumentParser:
         "--packages", nargs="*", help="CRAN package list or comma-separated."
     )
     sub.set_defaults(func=cmd_import_cran)
+
+    sub = subparsers.add_parser(
+        "create-item",
+        help="Create a Wikibase item from a typed schema or raw label/claims.",
+    )
+    sub.add_argument(
+        "--type",
+        metavar="TYPE",
+        help=f"Schema type for typed creation. Known types: {', '.join(sorted(KNOWN_TYPES))}.",
+    )
+    sub.add_argument(
+        "--fields",
+        metavar="JSON",
+        help="JSON object of fields for the typed schema (e.g. '{\"name\": \"My workflow\"}').",
+    )
+    sub.add_argument("--label", help="Item label (raw format).")
+    sub.add_argument("--description", help="Item description (raw format, optional).")
+    sub.add_argument(
+        "--claims",
+        metavar="JSON",
+        help="JSON object of claims for raw format (e.g. '{\"P31\": \"Q5\"}').",
+    )
+    sub.set_defaults(func=cmd_create_item)
 
     return parser
 

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -324,14 +324,24 @@ def cmd_create_item(args: argparse.Namespace) -> int:
     Returns:
         Process exit code.
     """
-    if args.type:
+    has_typed = bool(args.type)
+    has_raw = bool(args.label or args.claims or args.description)
+    if has_typed and has_raw:
+        print(json.dumps({"error": "--type and --label/--claims/--description are mutually exclusive"}))
+        return 2
+
+    if has_typed:
         fields: dict = {}
         if args.fields:
             try:
-                fields = json.loads(args.fields)
+                parsed = json.loads(args.fields)
             except json.JSONDecodeError as exc:
                 print(json.dumps({"error": f"invalid JSON in --fields: {exc}"}))
                 return 2
+            if not isinstance(parsed, dict):
+                print(json.dumps({"error": "--fields must be a JSON object"}))
+                return 2
+            fields = parsed
         payload, ok = create_typed_item_sync(args.type, fields)
     else:
         if not args.label:
@@ -340,10 +350,14 @@ def cmd_create_item(args: argparse.Namespace) -> int:
         claims: dict = {}
         if args.claims:
             try:
-                claims = json.loads(args.claims)
+                parsed = json.loads(args.claims)
             except json.JSONDecodeError as exc:
                 print(json.dumps({"error": f"invalid JSON in --claims: {exc}"}))
                 return 2
+            if not isinstance(parsed, dict):
+                print(json.dumps({"error": "--claims must be a JSON object"}))
+                return 2
+            claims = parsed
         payload, ok = create_item_sync(args.label, args.description, claims)
 
     print(json.dumps(payload))

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -52,4 +52,4 @@ Create a knowledge graph item::
   # Raw format — supply label and explicit property/item IDs
   python -m cli.importer_cli create-item \
       --label "My item" \
-      --claims '{"P31": "Q5"}'
+      --claims '{"<MaRDI-PID>": "<MaRDI-QID>"}'

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -41,3 +41,15 @@ Run synchronous imports::
   python -m cli.importer_cli import-wikidata --qids Q42 Q1
   python -m cli.importer_cli import-doi --dois 10.1000/XYZ123
   python -m cli.importer_cli import-cran --packages dplyr ggplot2
+
+Create a knowledge graph item::
+
+  # Typed format — schema fills predefined claims automatically
+  python -m cli.importer_cli create-item \
+      --type WORKFLOW \
+      --fields '{"name": "My workflow", "problem_statement": "Solve X"}'
+
+  # Raw format — supply label and explicit property/item IDs
+  python -m cli.importer_cli create-item \
+      --label "My item" \
+      --claims '{"P31": "Q5"}'

--- a/services/item_schemas.py
+++ b/services/item_schemas.py
@@ -50,11 +50,12 @@ SCHEMAS: dict[str, dict] = {
                 "pid": "P16",
                 "required": False,
             },
-            # P28 — publication date: string, e.g. "2026-04-09"
+            # P28 — publication date: YYYY-MM-DD, converted to Wikibase time format
             "publication_date": {
                 "target": "claim",
                 "pid": "P28",
                 "required": False,
+                "value_format": "wikibase_time",
             },
             # P163 — copyright license: QID of a license, e.g. CC-BY-SA = Q57031
             "copyright_license": {
@@ -90,6 +91,14 @@ SCHEMAS: dict[str, dict] = {
 }
 
 KNOWN_TYPES: frozenset[str] = frozenset(SCHEMAS)
+
+
+def _to_wikibase_time(value: str) -> str:
+    """Convert a YYYY-MM-DD date string to Wikibase time format (+YYYY-MM-DDT00:00:00Z)."""
+    import re
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+        return f"+{value}T00:00:00Z"
+    return value
 
 
 def resolve_typed_item(
@@ -148,6 +157,8 @@ def resolve_typed_item(
         elif target == "description":
             description = value
         elif target == "claim":
+            if field_def.get("value_format") == "wikibase_time":
+                value = _to_wikibase_time(value)
             claim_dict: dict = {"pid": field_def["pid"], "value": value, "qualifiers": []}
             claim_by_field[key] = claim_dict
             claims.append(claim_dict)


### PR DESCRIPTION
Adds `create-item` subcommand supporting typed (`--type`/`--fields`) and raw (`--label`/`--claims`) formats
  - Updates `docs/cli.rst` with usage examples
  - Adds JSON-defined KG items to the README sources list


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `create-item` CLI command to create knowledge graph items from typed schema or raw label/claims.
  * Added support for JSON-defined knowledge graph items as an import source.

* **Documentation**
  * Updated CLI documentation with examples for the new item creation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->