### PR TITLE
Add update-item endpoint and CLI command

### DIFF
--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -22,6 +22,7 @@ from services.import_service import (
     normalize_list,
     trigger_doi_async,
     trigger_wikidata_async,
+    update_item_sync,
 )
 from services.item_schemas import KNOWN_TYPES
 from services.version import get_version
@@ -364,6 +365,36 @@ def cmd_create_item(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def cmd_update_item(args: argparse.Namespace) -> int:
+    """Update an existing Wikibase item's label, description, or claims.
+
+    Args:
+        args: Parsed CLI arguments.
+
+    Returns:
+        Process exit code.
+    """
+    claims: dict = {}
+    if args.claims:
+        try:
+            parsed = json.loads(args.claims)
+        except json.JSONDecodeError as exc:
+            print(json.dumps({"error": f"invalid JSON in --claims: {exc}"}))
+            return 2
+        if not isinstance(parsed, dict):
+            print(json.dumps({"error": "--claims must be a JSON object"}))
+            return 2
+        claims = parsed
+
+    if not args.label and not args.description and not claims:
+        print(json.dumps({"error": "at least one of --label, --description, or --claims must be provided"}))
+        return 2
+
+    payload, ok = update_item_sync(args.qid, args.label, args.description, claims, args.do_override)
+    print(json.dumps(payload))
+    return 0 if ok else 1
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI argument parser.
 
@@ -454,6 +485,33 @@ def build_parser() -> argparse.ArgumentParser:
         help="JSON object of claims for raw format (e.g. '{\"P31\": \"Q5\"}').",
     )
     sub.set_defaults(func=cmd_create_item)
+
+    sub = subparsers.add_parser(
+        "update-item",
+        help="Update an existing Wikibase item's label, description, or claims.",
+    )
+    sub.add_argument("--qid", required=True, help="QID of the item to update.")
+    sub.add_argument("--label", help="New English label (replaces existing).")
+    sub.add_argument("--description", help="New English description (replaces existing).")
+    sub.add_argument(
+        "--claims",
+        metavar="JSON",
+        help=(
+            "JSON object of property-value pairs to set, e.g. '{\"P16\": \"Q482723\"}'. "
+            "A list value sets multiple statements: '{\"P16\": [\"Q111\", \"Q482723\"]}'."
+        ),
+    )
+    sub.add_argument(
+        "--do-override",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow overriding existing claim values. Without this flag, the call is "
+            "refused if a property already has values. With it, supply the complete "
+            "new set of values — the server replaces existing ones entirely."
+        ),
+    )
+    sub.set_defaults(func=cmd_update_item)
 
     return parser
 

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -390,7 +390,13 @@ def cmd_update_item(args: argparse.Namespace) -> int:
         print(json.dumps({"error": "at least one of --label, --description, or --claims must be provided"}))
         return 2
 
-    payload, ok = update_item_sync(args.qid, args.label, args.description, claims, args.do_override)
+    payload, ok = update_item_sync(
+        args.qid,
+        label=args.label,
+        description=args.description,
+        claims=claims,
+        do_override=args.do_override,
+    )
     print(json.dumps(payload))
     return 0 if ok else 1
 

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -386,7 +386,7 @@ def cmd_update_item(args: argparse.Namespace) -> int:
             return 2
         claims = parsed
 
-    if not args.label and not args.description and not claims:
+    if args.label is None and args.description is None and not claims:
         print(json.dumps({"error": "at least one of --label, --description, or --claims must be provided"}))
         return 2
 

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -398,7 +398,15 @@ def update_item():
     label = data.get("label")
     description = data.get("description")
     claims = data.get("claims") or {}
-    do_override = bool(data.get("do_override", False))
+    raw_override = data.get("do_override", False)
+    if isinstance(raw_override, bool):
+        do_override = raw_override
+    elif isinstance(raw_override, str):
+        do_override = raw_override.lower() == "true"
+    elif isinstance(raw_override, int):
+        do_override = raw_override == 1
+    else:
+        do_override = False
 
     if not label and not description and not claims:
         return jsonify(error="at least one of label, description, or claims must be provided"), 400

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -396,7 +396,11 @@ def update_item():
         return jsonify(error="'qid' must be a non-empty string"), 400
 
     label = data.get("label")
+    if label is not None and not isinstance(label, str):
+        return jsonify(error="'label' must be a string"), 400
     description = data.get("description")
+    if description is not None and not isinstance(description, str):
+        return jsonify(error="'description' must be a string"), 400
     claims = data.get("claims", {})
     if claims is None:
         claims = {}

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -392,12 +392,14 @@ def update_item():
     """
     data = request.get_json(silent=True) or {}
     qid = data.get("qid")
-    if not qid:
-        return jsonify(error="missing qid"), 400
+    if not isinstance(qid, str) or not qid:
+        return jsonify(error="'qid' must be a non-empty string"), 400
 
     label = data.get("label")
     description = data.get("description")
-    claims = data.get("claims") or {}
+    claims = data.get("claims", {})
+    if claims is None:
+        claims = {}
     raw_override = data.get("do_override", False)
     if isinstance(raw_override, bool):
         do_override = raw_override
@@ -418,6 +420,8 @@ def update_item():
     if not ok:
         if payload.get("status") == "conflict":
             return jsonify(payload), 409
+        if payload.get("status") == "not_found":
+            return jsonify(payload), 404
         return jsonify(payload), 500
     return jsonify(payload), 200
 

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -20,6 +20,7 @@ from services.import_service import (
     trigger_doi_async,
     trigger_wikidata_async,
     trigger_update_wikidata_async,
+    update_item_sync,
 )
 from services.item_schemas import KNOWN_TYPES
 from services.version import get_version
@@ -370,6 +371,47 @@ def create_item():
     claims = data.get("claims", {})
     payload, ok = create_item_sync(label, description, claims)
     return jsonify(payload), 200 if ok else 500
+
+
+@app.post("/update/item")
+def update_item():
+    """Update an existing Wikibase item's label, description, or claims.
+
+    Accepts a JSON body with the following fields:
+
+    - ``qid`` (required): QID of the item to update.
+    - ``label``: New English label.
+    - ``description``: New English description.
+    - ``claims``: Mapping of property IDs to value or list of values.
+    - ``do_override``: If true, existing claim values are replaced. If false
+      (default) and a property already has values, the request is refused
+      with HTTP 409 and the existing values are returned.
+
+    Returns:
+        Flask response tuple with update status.
+    """
+    data = request.get_json(silent=True) or {}
+    qid = data.get("qid")
+    if not qid:
+        return jsonify(error="missing qid"), 400
+
+    label = data.get("label")
+    description = data.get("description")
+    claims = data.get("claims") or {}
+    do_override = bool(data.get("do_override", False))
+
+    if not label and not description and not claims:
+        return jsonify(error="at least one of label, description, or claims must be provided"), 400
+
+    if not isinstance(claims, dict):
+        return jsonify(error="'claims' must be a JSON object"), 400
+
+    payload, ok = update_item_sync(qid, label, description, claims, do_override)
+    if not ok:
+        if payload.get("status") == "conflict":
+            return jsonify(payload), 409
+        return jsonify(payload), 500
+    return jsonify(payload), 200
 
 
 if __name__ == "__main__":

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -396,11 +396,11 @@ def update_item():
         return jsonify(error="'qid' must be a non-empty string"), 400
 
     label = data.get("label")
-    if label is not None and not isinstance(label, str):
-        return jsonify(error="'label' must be a string"), 400
+    if label is not None and (not isinstance(label, str) or not label):
+        return jsonify(error="'label' must be a non-empty string"), 400
     description = data.get("description")
-    if description is not None and not isinstance(description, str):
-        return jsonify(error="'description' must be a string"), 400
+    if description is not None and (not isinstance(description, str) or not description):
+        return jsonify(error="'description' must be a non-empty string"), 400
     claims = data.get("claims", {})
     if claims is None:
         claims = {}
@@ -420,7 +420,13 @@ def update_item():
     if not isinstance(claims, dict):
         return jsonify(error="'claims' must be a JSON object"), 400
 
-    payload, ok = update_item_sync(qid, label, description, claims, do_override)
+    payload, ok = update_item_sync(
+        qid,
+        label=label,
+        description=description,
+        claims=claims,
+        do_override=do_override,
+    )
     if not ok:
         if payload.get("status") == "conflict":
             return jsonify(payload), 409

--- a/flask_app/app.py
+++ b/flask_app/app.py
@@ -404,6 +404,9 @@ def update_item():
     claims = data.get("claims", {})
     if claims is None:
         claims = {}
+    if not isinstance(claims, dict):
+        return jsonify(error="'claims' must be a JSON object"), 400
+
     raw_override = data.get("do_override", False)
     if isinstance(raw_override, bool):
         do_override = raw_override
@@ -414,11 +417,8 @@ def update_item():
     else:
         do_override = False
 
-    if not label and not description and not claims:
+    if label is None and description is None and not claims:
         return jsonify(error="at least one of label, description, or claims must be provided"), 400
-
-    if not isinstance(claims, dict):
-        return jsonify(error="'claims' must be a JSON object"), 400
 
     payload, ok = update_item_sync(
         qid,

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -621,7 +621,7 @@ def update_item_sync(
         item = api.item.get(entity_id=qid)
     except Exception as exc:
         log.error("Failed to fetch item %s: %s", qid, exc)
-        return {"qid": qid, "status": "not_found", "error": f"Item not found: {exc}"}, False
+        return {"qid": qid, "status": "not_found", "error": "Item not found"}, False
 
     if label is not None:
         item.labels.set(language="en", value=label)
@@ -629,15 +629,16 @@ def update_item_sync(
         item.descriptions.set(language="en", value=description)
 
     for pid, value in (claims or {}).items():
-        existing = item.claims.get(pid)
+        norm_pid = pid.rsplit("/", 1)[-1].rsplit(":", 1)[-1] if isinstance(pid, str) else pid
+        existing = item.claims.get(norm_pid)
         if existing and not do_override:
             existing_values = _extract_claim_values(existing)
-            log.warning("Conflict on %s property %s: existing=%s", qid, pid, existing_values)
+            log.warning("Conflict on %s property %s: existing=%s", qid, norm_pid, existing_values)
             return {
                 "qid": qid,
                 "status": "conflict",
                 "error": (
-                    f"Property {pid} already has values: {existing_values}. "
+                    f"Property {norm_pid} already has values: {existing_values}. "
                     "Retrieve current values, merge, and resubmit with do_override=true."
                 ),
                 "existing_values": existing_values,
@@ -646,13 +647,13 @@ def update_item_sync(
             for claim in list(existing):
                 claim.remove()
         for v in (value if isinstance(value, list) else [value]):
-            item.add_claim(pid, v)
+            item.add_claim(norm_pid, v)
 
     try:
         result = item.write()
     except Exception as exc:
         log.error("Failed to write item %s: %s", qid, exc)
-        return {"qid": qid, "status": "error", "error": f"Item could not be updated: {exc}"}, False
+        return {"qid": qid, "status": "error", "error": "Item could not be updated"}, False
 
     updated_qid = result.id if result else None
     if updated_qid:

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -661,7 +661,7 @@ def update_item_sync(
         return {"qid": qid, "status": "updated"}, True
 
     log.error("Failed to update item %s.", qid)
-    return {"qid": qid, "status": "error", "error": "Item could not be updated."}, False
+    return {"qid": qid, "status": "error", "error": "Item could not be updated"}, False
 
 
 def import_doi_sync(dois: list[str]) -> tuple[dict, bool]:

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -567,6 +567,96 @@ def create_typed_item_sync(type_name: str, fields: dict) -> tuple[dict, bool]:
     return {"qid": None, "status": "error", "error": "Item could not be created."}, False
 
 
+def _extract_claim_values(claims: list) -> list[str]:
+    """Extract human-readable values from a list of WBI Claim objects."""
+    values = []
+    for claim in claims:
+        dv = claim.mainsnak.datavalue
+        if not dv:
+            continue
+        v = dv.get("value") if isinstance(dv, dict) else None
+        if isinstance(v, dict) and "id" in v:
+            values.append(v["id"])
+        elif isinstance(v, str):
+            values.append(v)
+        elif v is not None:
+            values.append(str(v))
+    return values
+
+
+def update_item_sync(
+    qid: str,
+    label: str | None = None,
+    description: str | None = None,
+    claims: dict | None = None,
+    do_override: bool = False,
+) -> tuple[dict, bool]:
+    """Update an existing Wikibase item's label, description, or claims.
+
+    For claims, if a property already has values the call is refused unless
+    ``do_override=True``, in which case the provided value(s) fully replace the
+    existing ones. Pass a list as the value to set multiple statements at once.
+
+    Args:
+        qid: QID of the item to update.
+        label: New English label (always replaces existing).
+        description: New English description (always replaces existing).
+        claims: Mapping of property IDs to value(s) to set.
+        do_override: When True, existing claim values are replaced rather than
+            raising a conflict error.
+
+    Returns:
+        Tuple of payload dict and success flag.
+    """
+    api = MardiClient(
+        user=os.environ["WIKIDATA_USER"],
+        password=os.environ["WIKIDATA_PASS"],
+        mediawiki_api_url=os.environ.get("MEDIAWIKI_API_URL"),
+        sparql_endpoint_url=os.environ.get("SPARQL_ENDPOINT_URL"),
+        wikibase_url=os.environ.get("WIKIBASE_URL"),
+        importer_api_url=os.environ.get("IMPORTER_API_URL"),
+    )
+
+    try:
+        item = api.item.get(entity_id=qid)
+    except Exception as exc:
+        log.error("Failed to fetch item %s: %s", qid, exc)
+        return {"qid": qid, "status": "error", "error": f"Item not found: {exc}"}, False
+
+    if label:
+        item.labels.set(language="en", value=label)
+    if description:
+        item.descriptions.set(language="en", value=description)
+
+    for pid, value in (claims or {}).items():
+        existing = item.claims.get(pid)
+        if existing and not do_override:
+            existing_values = _extract_claim_values(existing)
+            log.warning("Conflict on %s property %s: existing=%s", qid, pid, existing_values)
+            return {
+                "qid": qid,
+                "status": "conflict",
+                "error": (
+                    f"Property {pid} already has values: {existing_values}. "
+                    "Retrieve current values, merge, and resubmit with do_override=true."
+                ),
+                "existing_values": existing_values,
+            }, False
+        if existing:
+            for claim in list(existing):
+                claim.remove()
+        for v in (value if isinstance(value, list) else [value]):
+            item.add_claim(pid, v)
+
+    result = item.write()
+    if result:
+        log.info("Updated item %s.", qid)
+        return {"qid": qid, "status": "updated"}, True
+
+    log.error("Failed to update item %s.", qid)
+    return {"qid": qid, "status": "error", "error": "Item could not be updated."}, False
+
+
 def import_doi_sync(dois: list[str]) -> tuple[dict, bool]:
     """Import publications by DOI from supported sources.
 

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -621,7 +621,7 @@ def update_item_sync(
         item = api.item.get(entity_id=qid)
     except Exception as exc:
         log.error("Failed to fetch item %s: %s", qid, exc)
-        return {"qid": qid, "status": "error", "error": f"Item not found: {exc}"}, False
+        return {"qid": qid, "status": "not_found", "error": f"Item not found: {exc}"}, False
 
     if label:
         item.labels.set(language="en", value=label)
@@ -654,7 +654,8 @@ def update_item_sync(
         log.error("Failed to write item %s: %s", qid, exc)
         return {"qid": qid, "status": "error", "error": f"Item could not be updated: {exc}"}, False
 
-    if result:
+    updated_qid = result.id if result else None
+    if updated_qid:
         log.info("Updated item %s.", qid)
         return {"qid": qid, "status": "updated"}, True
 

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -648,7 +648,12 @@ def update_item_sync(
         for v in (value if isinstance(value, list) else [value]):
             item.add_claim(pid, v)
 
-    result = item.write()
+    try:
+        result = item.write()
+    except Exception as exc:
+        log.error("Failed to write item %s: %s", qid, exc)
+        return {"qid": qid, "status": "error", "error": f"Item could not be updated: {exc}"}, False
+
     if result:
         log.info("Updated item %s.", qid)
         return {"qid": qid, "status": "updated"}, True

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -623,9 +623,9 @@ def update_item_sync(
         log.error("Failed to fetch item %s: %s", qid, exc)
         return {"qid": qid, "status": "not_found", "error": f"Item not found: {exc}"}, False
 
-    if label:
+    if label is not None:
         item.labels.set(language="en", value=label)
-    if description:
+    if description is not None:
         item.descriptions.set(language="en", value=description)
 
     for pid, value in (claims or {}).items():

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -50,6 +50,7 @@ _install_flask_stub()
 from flask_app.app import (
     health,
     create_item,
+    update_item,
     import_wikidata_async,
     import_workflow_status,
     import_workflow_result,
@@ -366,6 +367,83 @@ class TestFlaskApp(unittest.TestCase):
 
         self.assertEqual(status, 500)
         self.assertEqual(response["status"], "error")
+
+
+    def test_update_item_missing_qid(self) -> None:
+        fake_request.get_json.return_value = {"label": "x"}
+        response, status = update_item()
+        self.assertEqual(status, 400)
+        self.assertIn("qid", response["error"])
+
+    def test_update_item_non_string_qid(self) -> None:
+        fake_request.get_json.return_value = {"qid": 123, "label": "x"}
+        response, status = update_item()
+        self.assertEqual(status, 400)
+        self.assertIn("qid", response["error"])
+
+    def test_update_item_invalid_label_type(self) -> None:
+        fake_request.get_json.return_value = {"qid": "Q1", "label": 42}
+        response, status = update_item()
+        self.assertEqual(status, 400)
+        self.assertIn("label", response["error"])
+
+    def test_update_item_invalid_description_type(self) -> None:
+        fake_request.get_json.return_value = {"qid": "Q1", "description": ["bad"]}
+        response, status = update_item()
+        self.assertEqual(status, 400)
+        self.assertIn("description", response["error"])
+
+    def test_update_item_invalid_claims_type(self) -> None:
+        fake_request.get_json.return_value = {"qid": "Q1", "claims": "bad"}
+        response, status = update_item()
+        self.assertEqual(status, 400)
+        self.assertIn("claims", response["error"])
+
+    def test_update_item_empty_payload(self) -> None:
+        fake_request.get_json.return_value = {"qid": "Q1"}
+        response, status = update_item()
+        self.assertEqual(status, 400)
+        self.assertIn("at least one", response["error"])
+
+    def test_update_item_success(self) -> None:
+        fake_request.get_json.return_value = {"qid": "Q1", "label": "New label"}
+        with patch("flask_app.app.update_item_sync",
+                   return_value=({"qid": "Q1", "status": "updated"}, True)):
+            response, status = update_item()
+        self.assertEqual(status, 200)
+        self.assertEqual(response["status"], "updated")
+
+    def test_update_item_conflict(self) -> None:
+        fake_request.get_json.return_value = {"qid": "Q1", "claims": {"P16": "Q99"}}
+        conflict = {
+            "qid": "Q1",
+            "status": "conflict",
+            "error": "P16 already has values",
+            "existing_values": ["Q50"],
+        }
+        with patch("flask_app.app.update_item_sync", return_value=(conflict, False)):
+            response, status = update_item()
+        self.assertEqual(status, 409)
+        self.assertEqual(response["status"], "conflict")
+
+    def test_update_item_not_found(self) -> None:
+        fake_request.get_json.return_value = {"qid": "Q999", "label": "x"}
+        not_found = {"qid": "Q999", "status": "not_found", "error": "Item not found"}
+        with patch("flask_app.app.update_item_sync", return_value=(not_found, False)):
+            response, status = update_item()
+        self.assertEqual(status, 404)
+        self.assertEqual(response["status"], "not_found")
+
+    def test_update_item_do_override_string_false(self) -> None:
+        """String 'false' must not enable override mode."""
+        fake_request.get_json.return_value = {
+            "qid": "Q1", "claims": {"P16": "Q99"}, "do_override": "false"
+        }
+        conflict = {"qid": "Q1", "status": "conflict", "error": "x", "existing_values": []}
+        with patch("flask_app.app.update_item_sync", return_value=(conflict, False)) as m:
+            _, status = update_item()
+        self.assertEqual(status, 409)
+        self.assertFalse(m.call_args.args[4])
 
 
 if __name__ == "__main__":

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -443,7 +443,7 @@ class TestFlaskApp(unittest.TestCase):
         with patch("flask_app.app.update_item_sync", return_value=(conflict, False)) as m:
             _, status = update_item()
         self.assertEqual(status, 409)
-        self.assertFalse(m.call_args.args[4])
+        self.assertFalse(m.call_args.kwargs["do_override"])
 
 
 if __name__ == "__main__":

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -292,5 +292,88 @@ class TestImportService(unittest.TestCase):
         self.assertEqual(payload["results"]["badpkg"]["status"], "not_found")
 
 
+    def _make_mock_api(self, existing_claims=None):
+        """Return a (api_mock, item_mock) pair wired for update_item_sync tests."""
+        claim = Mock()
+        claim.mainsnak.datavalue = {"value": {"id": "Q50"}}
+
+        item = Mock()
+        item.claims.get.return_value = existing_claims
+        result = Mock()
+        result.id = "Q1"
+        item.write.return_value = result
+
+        api = Mock()
+        api.item.get.return_value = item
+        return api, item
+
+    def test_update_item_sync_success_no_existing(self) -> None:
+        """Add a claim when the property has no existing values."""
+        api, item = self._make_mock_api(existing_claims=None)
+        env = {"WIKIDATA_USER": "u", "WIKIDATA_PASS": "p"}
+        with patch.dict("os.environ", env), \
+             patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync(
+                "Q1", claims={"P16": "Q99"}
+            )
+        self.assertTrue(ok)
+        self.assertEqual(payload["status"], "updated")
+        item.add_claim.assert_called_once_with("P16", "Q99")
+
+    def test_update_item_sync_conflict_no_override(self) -> None:
+        """Refuse when a property has values and do_override is False."""
+        claim = Mock()
+        claim.mainsnak.datavalue = {"value": {"id": "Q50"}}
+        api, item = self._make_mock_api(existing_claims=[claim])
+        env = {"WIKIDATA_USER": "u", "WIKIDATA_PASS": "p"}
+        with patch.dict("os.environ", env), \
+             patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync(
+                "Q1", claims={"P16": "Q99"}, do_override=False
+            )
+        self.assertFalse(ok)
+        self.assertEqual(payload["status"], "conflict")
+        self.assertIn("Q50", payload["existing_values"])
+        item.write.assert_not_called()
+
+    def test_update_item_sync_override_replaces_existing(self) -> None:
+        """With do_override=True, remove existing claims and add new ones."""
+        old_claim = Mock()
+        old_claim.mainsnak.datavalue = {"value": {"id": "Q50"}}
+        api, item = self._make_mock_api(existing_claims=[old_claim])
+        env = {"WIKIDATA_USER": "u", "WIKIDATA_PASS": "p"}
+        with patch.dict("os.environ", env), \
+             patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync(
+                "Q1", claims={"P16": ["Q50", "Q99"]}, do_override=True
+            )
+        self.assertTrue(ok)
+        old_claim.remove.assert_called_once()
+        self.assertEqual(item.add_claim.call_count, 2)
+
+    def test_update_item_sync_item_not_found(self) -> None:
+        """Return not_found status when api.item.get raises."""
+        api = Mock()
+        api.item.get.side_effect = Exception("no such item")
+        env = {"WIKIDATA_USER": "u", "WIKIDATA_PASS": "p"}
+        with patch.dict("os.environ", env), \
+             patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync("Q999", label="x")
+        self.assertFalse(ok)
+        self.assertEqual(payload["status"], "not_found")
+
+    def test_update_item_sync_write_exception(self) -> None:
+        """Return error status when item.write raises."""
+        api, item = self._make_mock_api(existing_claims=None)
+        item.write.side_effect = Exception("write failed")
+        env = {"WIKIDATA_USER": "u", "WIKIDATA_PASS": "p"}
+        with patch.dict("os.environ", env), \
+             patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync("Q1", label="x")
+        self.assertFalse(ok)
+        self.assertEqual(payload["status"], "error")
+        self.assertIn("write failed", payload["error"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -294,9 +294,6 @@ class TestImportService(unittest.TestCase):
 
     def _make_mock_api(self, existing_claims=None):
         """Return a (api_mock, item_mock) pair wired for update_item_sync tests."""
-        claim = Mock()
-        claim.mainsnak.datavalue = {"value": {"id": "Q50"}}
-
         item = Mock()
         item.claims.get.return_value = existing_claims
         result = Mock()

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -317,6 +317,18 @@ class TestImportService(unittest.TestCase):
         self.assertEqual(payload["status"], "updated")
         item.add_claim.assert_called_once_with("P16", "Q99")
 
+    def test_update_item_sync_prefixed_pid_normalized(self) -> None:
+        """Prefixed PID ('wdt:P16') is normalized to bare form before lookup and add."""
+        api, item = self._make_mock_api(existing_claims=None)
+        env = {"WIKIDATA_USER": "u", "WIKIDATA_PASS": "p"}
+        with patch.dict("os.environ", env), \
+             patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync(
+                "Q1", claims={"wdt:P16": "Q99"}
+            )
+        self.assertTrue(ok)
+        item.add_claim.assert_called_once_with("P16", "Q99")
+
     def test_update_item_sync_conflict_no_override(self) -> None:
         """Refuse when a property has values and do_override is False."""
         claim = Mock()
@@ -369,7 +381,7 @@ class TestImportService(unittest.TestCase):
             payload, ok = import_service.update_item_sync("Q1", label="x")
         self.assertFalse(ok)
         self.assertEqual(payload["status"], "error")
-        self.assertIn("write failed", payload["error"])
+        self.assertEqual(payload["error"], "Item could not be updated")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

  - New \`POST /update/item\` Flask endpoint for updating an existing Wikibase item's label, description, or claims
  - New \`update_item_sync()\` service function using \`api.item.get()\` + patch + write
  - New \`update-item\` CLI subcommand with \`--qid\`, \`--label\`, \`--description\`, \`--claims\`, \`--do-override\`

## Conflict guard

If a property already has values and \`do_override\` is not set, the request is refused with HTTP 409 and the existing values are returned so the caller can merge. With \`do_override=true\`, the provided value(s) fully replace existing claims for that property. Lists are supported for setting multiple statements at once.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an `update-item` CLI command to update item label, description, and claims, with an optional override mode.
- Introduced a new `POST /update/item` API endpoint supporting JSON updates and returning appropriate status codes for success, conflicts, and missing items.

## Tests
- Expanded unit test coverage for the new CLI/API behavior, including input validation, conflict handling with existing values, override behavior, and not-found/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->