### PR TITLE
Require explicit credentials for CLI create-item and update-item

### DIFF
--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -343,7 +343,7 @@ def cmd_create_item(args: argparse.Namespace) -> int:
                 print(json.dumps({"error": "--fields must be a JSON object"}))
                 return 2
             fields = parsed
-        payload, ok = create_typed_item_sync(args.type, fields)
+        payload, ok = create_typed_item_sync(args.type, fields, username=args.username, password=args.password)
     else:
         if not args.label:
             print(json.dumps({"error": "either --type or --label is required"}))
@@ -359,7 +359,7 @@ def cmd_create_item(args: argparse.Namespace) -> int:
                 print(json.dumps({"error": "--claims must be a JSON object"}))
                 return 2
             claims = parsed
-        payload, ok = create_item_sync(args.label, args.description, claims)
+        payload, ok = create_item_sync(args.label, args.description, claims, username=args.username, password=args.password)
 
     print(json.dumps(payload))
     return 0 if ok else 1
@@ -396,6 +396,8 @@ def cmd_update_item(args: argparse.Namespace) -> int:
         description=args.description,
         claims=claims,
         do_override=args.do_override,
+        username=args.username,
+        password=args.password,
     )
     print(json.dumps(payload))
     return 0 if ok else 1
@@ -490,6 +492,8 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="JSON",
         help="JSON object of claims for raw format (e.g. '{\"P31\": \"Q5\"}').",
     )
+    sub.add_argument("--username", required=True, help="Wiki bot username (User@BotName).")
+    sub.add_argument("--password", required=True, help="Wiki bot password.")
     sub.set_defaults(func=cmd_create_item)
 
     sub = subparsers.add_parser(
@@ -517,6 +521,8 @@ def build_parser() -> argparse.ArgumentParser:
             "new set of values — the server replaces existing ones entirely."
         ),
     )
+    sub.add_argument("--username", required=True, help="Wiki bot username (User@BotName).")
+    sub.add_argument("--password", required=True, help="Wiki bot password.")
     sub.set_defaults(func=cmd_update_item)
 
     return parser

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -339,9 +339,13 @@ def _resolve_credentials(args: argparse.Namespace) -> tuple[str, str] | None:
         return None
 
     if raw_password == "-":
-        password = sys.stdin.readline().rstrip("\n")
+        if sys.stdin.isatty():
+            import getpass
+            password = getpass.getpass("Wiki password: ")
+        else:
+            password = sys.stdin.readline().rstrip("\n")
         if not password:
-            print(json.dumps({"error": "empty password read from stdin"}))
+            print(json.dumps({"error": "empty password"}))
             return None
     else:
         password = raw_password

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -316,6 +316,39 @@ def cmd_import_cran(args: argparse.Namespace) -> int:
     return 0 if all_ok else 1
 
 
+def _resolve_credentials(args: argparse.Namespace) -> tuple[str, str] | None:
+    """Resolve wiki credentials from args or environment variables.
+
+    Password may be the literal string ``-`` to trigger a stdin read.
+    Falls back to ``WIKI_USER`` / ``WIKI_PASS`` env vars when the
+    corresponding argument is not supplied.
+
+    Returns:
+        (username, password) tuple, or None if either is missing.
+    """
+    username = args.username or os.environ.get("WIKI_USER")
+    raw_password = args.password or os.environ.get("WIKI_PASS")
+
+    if not username or not raw_password:
+        missing = []
+        if not username:
+            missing.append("--username (or WIKI_USER)")
+        if not raw_password:
+            missing.append("--password (or WIKI_PASS)")
+        print(json.dumps({"error": f"missing credentials: {', '.join(missing)}"}))
+        return None
+
+    if raw_password == "-":
+        password = sys.stdin.readline().rstrip("\n")
+        if not password:
+            print(json.dumps({"error": "empty password read from stdin"}))
+            return None
+    else:
+        password = raw_password
+
+    return username, password
+
+
 def cmd_create_item(args: argparse.Namespace) -> int:
     """Create a Wikibase item from a typed schema or raw label/claims.
 
@@ -325,6 +358,11 @@ def cmd_create_item(args: argparse.Namespace) -> int:
     Returns:
         Process exit code.
     """
+    creds = _resolve_credentials(args)
+    if creds is None:
+        return 2
+    username, password = creds
+
     has_typed = bool(args.type)
     has_raw = bool(args.label or args.claims or args.description)
     if has_typed and has_raw:
@@ -343,7 +381,7 @@ def cmd_create_item(args: argparse.Namespace) -> int:
                 print(json.dumps({"error": "--fields must be a JSON object"}))
                 return 2
             fields = parsed
-        payload, ok = create_typed_item_sync(args.type, fields, username=args.username, password=args.password)
+        payload, ok = create_typed_item_sync(args.type, fields, username=username, password=password)
     else:
         if not args.label:
             print(json.dumps({"error": "either --type or --label is required"}))
@@ -359,7 +397,7 @@ def cmd_create_item(args: argparse.Namespace) -> int:
                 print(json.dumps({"error": "--claims must be a JSON object"}))
                 return 2
             claims = parsed
-        payload, ok = create_item_sync(args.label, args.description, claims, username=args.username, password=args.password)
+        payload, ok = create_item_sync(args.label, args.description, claims, username=username, password=password)
 
     print(json.dumps(payload))
     return 0 if ok else 1
@@ -374,6 +412,11 @@ def cmd_update_item(args: argparse.Namespace) -> int:
     Returns:
         Process exit code.
     """
+    creds = _resolve_credentials(args)
+    if creds is None:
+        return 2
+    username, password = creds
+
     claims: dict = {}
     if args.claims:
         try:
@@ -396,8 +439,8 @@ def cmd_update_item(args: argparse.Namespace) -> int:
         description=args.description,
         claims=claims,
         do_override=args.do_override,
-        username=args.username,
-        password=args.password,
+        username=username,
+        password=password,
     )
     print(json.dumps(payload))
     return 0 if ok else 1
@@ -492,8 +535,8 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="JSON",
         help="JSON object of claims for raw format (e.g. '{\"P31\": \"Q5\"}').",
     )
-    sub.add_argument("--username", required=True, help="Wiki bot username (User@BotName).")
-    sub.add_argument("--password", required=True, help="Wiki bot password.")
+    sub.add_argument("--username", help="Wiki bot username (User@BotName). Falls back to WIKI_USER env var.")
+    sub.add_argument("--password", help="Wiki bot password, or '-' to read from stdin. Falls back to WIKI_PASS env var.")
     sub.set_defaults(func=cmd_create_item)
 
     sub = subparsers.add_parser(
@@ -521,8 +564,8 @@ def build_parser() -> argparse.ArgumentParser:
             "new set of values — the server replaces existing ones entirely."
         ),
     )
-    sub.add_argument("--username", required=True, help="Wiki bot username (User@BotName).")
-    sub.add_argument("--password", required=True, help="Wiki bot password.")
+    sub.add_argument("--username", help="Wiki bot username (User@BotName). Falls back to WIKI_USER env var.")
+    sub.add_argument("--password", help="Wiki bot password, or '-' to read from stdin. Falls back to WIKI_PASS env var.")
     sub.set_defaults(func=cmd_update_item)
 
     return parser


### PR DESCRIPTION
## Summary

  - `create-item` and `update-item` CLI subcommands now require `--username` and `--password` arguments
  - Credentials are passed through to `create_item_sync`, `create_typed_item_sync`, and `update_item_sync`
  - Consistent with the Flask API and DOIP paths where credentials are already strictly required — every write to the knowledge graph must be
  attributed to a specific user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Item creation and update operations now authenticate using `--username` and `--password` provided to the `create-item` and `update-item` commands.
  * `--password -` reads the password from standard input.
  * If credentials are missing (or the stdin password is empty), the command exits with an error code instead of attempting the operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->