### PR TITLE
Handle list values in create_item_sync claims

### DIFF
--- a/services/import_service.py
+++ b/services/import_service.py
@@ -511,7 +511,9 @@ def create_item_sync(
     if description:
         item.descriptions.set(language="en", value=description)
     for prop, value in (claims or {}).items():
-        item.add_claim(prop, value)
+        values_list = value if isinstance(value, list) else [value]
+        for v in values_list:
+            item.add_claim(prop, v)
 
     result = item.write()
     qid = result.id if result else None


### PR DESCRIPTION
## Summary

- `create_item_sync` was calling `item.add_claim(prop, value)` directly with the raw value, so passing a list (e.g. multiple QIDs for P31) would fail
- Align with the existing update path: unpack lists and call `add_claim` once per value


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multi-valued claims during item import. Claims with multiple values are now properly processed individually rather than as a single value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->