### PR TITLE
Add qualifier support to claim values in create and update

### DIFF
--- a/services/import_service.py
+++ b/services/import_service.py
@@ -602,7 +602,7 @@ def _parse_claim_value(v) -> tuple[Any, dict]:
     mapping qualifier P-IDs to their values. Non-dict qualifiers fields (e.g. null)
     are normalised to an empty dict rather than propagated.
     """
-    if isinstance(v, dict) and "value" in v and v.keys() <= {"value", "qualifiers"}:
+    if isinstance(v, dict) and "value" in v and "qualifiers" in v and v.keys() <= {"value", "qualifiers"}:
         qualifiers = v.get("qualifiers")
         return v["value"], qualifiers if isinstance(qualifiers, dict) else {}
     return v, {}
@@ -705,9 +705,10 @@ def update_item_sync(
             for v in values_list:
                 actual_val, qualifiers_dict = _parse_claim_value(v)
                 qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
-                if actual_val in existing_by_value and not qualifiers:
+                match_key = actual_val["id"] if isinstance(actual_val, dict) and "id" in actual_val else str(actual_val)
+                if match_key in existing_by_value and not qualifiers:
                     # No qualifier update — keep the existing claim as-is.
-                    existing_by_value[actual_val].removed = False
+                    existing_by_value[match_key].removed = False
                 else:
                     # New value, or same value with qualifier changes — add fresh claim.
                     item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -597,7 +597,7 @@ def create_typed_item_sync(
 
 def _norm_pid(pid: str) -> str:
     """Strip wdt:/full-URL prefix from a property ID, returning the bare P-number."""
-    return pid.rsplit("/", 1)[-1].rsplit(":", 1)[-1] if isinstance(pid, str) else pid
+    return pid.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
 
 
 def _parse_claim_value(v) -> tuple[Any, dict]:

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -511,11 +511,12 @@ def create_item_sync(
     if description:
         item.descriptions.set(language="en", value=description)
     for prop, value in (claims or {}).items():
+        norm_prop = _norm_pid(prop)
         values_list = value if isinstance(value, list) else [value]
         for v in values_list:
             actual_val, qualifiers_dict = _parse_claim_value(v)
-            qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
-            item.add_claim(prop, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
+            qualifiers = [api.get_claim(_norm_pid(q_pid), q_val) for q_pid, q_val in qualifiers_dict.items()]
+            item.add_claim(norm_prop, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
 
     result = item.write()
     qid = result.id if result else None
@@ -592,6 +593,11 @@ def create_typed_item_sync(
 
     log.error("Failed to create typed item (type=%s, label='%s').", type_name, label)
     return {"qid": None, "status": "error", "error": "Item could not be created."}, False
+
+
+def _norm_pid(pid: str) -> str:
+    """Strip wdt:/full-URL prefix from a property ID, returning the bare P-number."""
+    return pid.rsplit("/", 1)[-1].rsplit(":", 1)[-1] if isinstance(pid, str) else pid
 
 
 def _parse_claim_value(v) -> tuple[Any, dict]:
@@ -680,7 +686,7 @@ def update_item_sync(
         item.descriptions.set(language="en", value=description)
 
     for pid, value in (claims or {}).items():
-        norm_pid = pid.rsplit("/", 1)[-1].rsplit(":", 1)[-1] if isinstance(pid, str) else pid
+        norm_pid = _norm_pid(pid)
         existing = item.claims.get(norm_pid)
         if existing and not do_override:
             existing_values = _extract_claim_values(existing)
@@ -704,7 +710,7 @@ def update_item_sync(
                 claim.remove()
             for v in values_list:
                 actual_val, qualifiers_dict = _parse_claim_value(v)
-                qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
+                qualifiers = [api.get_claim(_norm_pid(q_pid), q_val) for q_pid, q_val in qualifiers_dict.items()]
                 explicit_qualifiers = (
                     isinstance(v, dict)
                     and "value" in v
@@ -721,7 +727,7 @@ def update_item_sync(
         else:
             for v in values_list:
                 actual_val, qualifiers_dict = _parse_claim_value(v)
-                qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
+                qualifiers = [api.get_claim(_norm_pid(q_pid), q_val) for q_pid, q_val in qualifiers_dict.items()]
                 item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
 
     try:

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -705,12 +705,18 @@ def update_item_sync(
             for v in values_list:
                 actual_val, qualifiers_dict = _parse_claim_value(v)
                 qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
+                explicit_qualifiers = (
+                    isinstance(v, dict)
+                    and "value" in v
+                    and "qualifiers" in v
+                    and v.keys() <= {"value", "qualifiers"}
+                )
                 match_key = actual_val["id"] if isinstance(actual_val, dict) and "id" in actual_val else str(actual_val)
-                if match_key in existing_by_value and not qualifiers:
-                    # No qualifier update — keep the existing claim as-is.
+                if match_key in existing_by_value and not qualifiers and not explicit_qualifiers:
+                    # Bare value with no qualifier intent — keep the existing claim as-is.
                     existing_by_value[match_key].removed = False
                 else:
-                    # New value, or same value with qualifier changes — add fresh claim.
+                    # New value, qualifier change, or explicit empty-qualifier override — add fresh claim.
                     item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
         else:
             for v in values_list:

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -600,7 +600,7 @@ def _norm_pid(pid: str) -> str:
     return pid.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
 
 
-def _parse_claim_value(v) -> tuple[Any, dict]:
+def _parse_claim_value(v: Any) -> tuple[Any, dict[str, Any]]:
     """Extract (actual_value, qualifiers_dict) from a claim value spec.
 
     Accepts either a bare scalar or ``{"value": ..., "qualifiers": {"P984": "Q123"}}``

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -513,7 +513,9 @@ def create_item_sync(
     for prop, value in (claims or {}).items():
         values_list = value if isinstance(value, list) else [value]
         for v in values_list:
-            item.add_claim(prop, v)
+            actual_val, qualifiers_dict = _parse_claim_value(v)
+            qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
+            item.add_claim(prop, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
 
     result = item.write()
     qid = result.id if result else None
@@ -590,6 +592,18 @@ def create_typed_item_sync(
 
     log.error("Failed to create typed item (type=%s, label='%s').", type_name, label)
     return {"qid": None, "status": "error", "error": "Item could not be created."}, False
+
+
+def _parse_claim_value(v) -> tuple:
+    """Extract (actual_value, qualifiers_dict) from a claim value spec.
+
+    Accepts either a bare scalar or ``{"value": ..., "qualifiers": {"P984": "Q123"}}``
+    object form. Returns a 2-tuple of the actual value and a (possibly empty) dict
+    mapping qualifier P-IDs to their values.
+    """
+    if isinstance(v, dict) and "value" in v:
+        return v["value"], v.get("qualifiers", {})
+    return v, {}
 
 
 def _extract_claim_values(claims: list) -> list[str]:
@@ -687,13 +701,17 @@ def update_item_sync(
                     existing_by_value[vals[0]] = claim
                 claim.remove()
             for v in values_list:
-                if v in existing_by_value:
-                    existing_by_value[v].removed = False
+                actual_val, qualifiers_dict = _parse_claim_value(v)
+                qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
+                if actual_val in existing_by_value:
+                    existing_by_value[actual_val].removed = False
                 else:
-                    item.add_claim(norm_pid, v)
+                    item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
         else:
             for v in values_list:
-                item.add_claim(norm_pid, v)
+                actual_val, qualifiers_dict = _parse_claim_value(v)
+                qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
+                item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
 
     try:
         result = item.write()

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -514,7 +514,7 @@ def create_item_sync(
         norm_prop = _norm_pid(prop)
         values_list = value if isinstance(value, list) else [value]
         for v in values_list:
-            actual_val, qualifiers_dict = _parse_claim_value(v)
+            actual_val, qualifiers_dict, _ = _parse_claim_value(v)
             qualifiers = [api.get_claim(_norm_pid(q_pid), q_val) for q_pid, q_val in qualifiers_dict.items()]
             item.add_claim(norm_prop, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
 
@@ -600,18 +600,19 @@ def _norm_pid(pid: str) -> str:
     return pid.rsplit("/", 1)[-1].rsplit(":", 1)[-1]
 
 
-def _parse_claim_value(v: Any) -> tuple[Any, dict[str, Any]]:
-    """Extract (actual_value, qualifiers_dict) from a claim value spec.
+def _parse_claim_value(v: Any) -> tuple[Any, dict[str, Any], bool]:
+    """Extract (actual_value, qualifiers_dict, explicit_qualifiers) from a claim value spec.
 
     Accepts either a bare scalar or ``{"value": ..., "qualifiers": {"P984": "Q123"}}``
-    object form. Returns a 2-tuple of the actual value and a (possibly empty) dict
-    mapping qualifier P-IDs to their values. Non-dict qualifiers fields (e.g. null)
-    are normalised to an empty dict rather than propagated.
+    object form. Returns a 3-tuple: the actual value, a (possibly empty) dict of qualifier
+    P-IDs to values, and a boolean indicating whether the caller used the object form
+    (i.e. explicitly declared qualifier intent, even if qualifiers dict is empty).
+    Non-dict qualifiers fields (e.g. null) are normalised to an empty dict.
     """
     if isinstance(v, dict) and "value" in v and "qualifiers" in v and v.keys() <= {"value", "qualifiers"}:
         qualifiers = v.get("qualifiers")
-        return v["value"], qualifiers if isinstance(qualifiers, dict) else {}
-    return v, {}
+        return v["value"], qualifiers if isinstance(qualifiers, dict) else {}, True
+    return v, {}, False
 
 
 def _extract_claim_values(claims: list) -> list[str]:
@@ -709,14 +710,8 @@ def update_item_sync(
                     existing_by_value[vals[0]] = claim
                 claim.remove()
             for v in values_list:
-                actual_val, qualifiers_dict = _parse_claim_value(v)
+                actual_val, qualifiers_dict, explicit_qualifiers = _parse_claim_value(v)
                 qualifiers = [api.get_claim(_norm_pid(q_pid), q_val) for q_pid, q_val in qualifiers_dict.items()]
-                explicit_qualifiers = (
-                    isinstance(v, dict)
-                    and "value" in v
-                    and "qualifiers" in v
-                    and v.keys() <= {"value", "qualifiers"}
-                )
                 match_key = actual_val["id"] if isinstance(actual_val, dict) and "id" in actual_val else str(actual_val)
                 if match_key in existing_by_value and not qualifiers and not explicit_qualifiers:
                     # Bare value with no qualifier intent — keep the existing claim as-is.
@@ -726,7 +721,7 @@ def update_item_sync(
                     item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
         else:
             for v in values_list:
-                actual_val, qualifiers_dict = _parse_claim_value(v)
+                actual_val, qualifiers_dict, _ = _parse_claim_value(v)
                 qualifiers = [api.get_claim(_norm_pid(q_pid), q_val) for q_pid, q_val in qualifiers_dict.items()]
                 item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
 

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -602,7 +602,7 @@ def _parse_claim_value(v) -> tuple[Any, dict]:
     mapping qualifier P-IDs to their values. Non-dict qualifiers fields (e.g. null)
     are normalised to an empty dict rather than propagated.
     """
-    if isinstance(v, dict) and "value" in v:
+    if isinstance(v, dict) and "value" in v and v.keys() <= {"value", "qualifiers"}:
         qualifiers = v.get("qualifiers")
         return v["value"], qualifiers if isinstance(qualifiers, dict) else {}
     return v, {}

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -594,15 +594,17 @@ def create_typed_item_sync(
     return {"qid": None, "status": "error", "error": "Item could not be created."}, False
 
 
-def _parse_claim_value(v) -> tuple:
+def _parse_claim_value(v) -> tuple[Any, dict]:
     """Extract (actual_value, qualifiers_dict) from a claim value spec.
 
     Accepts either a bare scalar or ``{"value": ..., "qualifiers": {"P984": "Q123"}}``
     object form. Returns a 2-tuple of the actual value and a (possibly empty) dict
-    mapping qualifier P-IDs to their values.
+    mapping qualifier P-IDs to their values. Non-dict qualifiers fields (e.g. null)
+    are normalised to an empty dict rather than propagated.
     """
     if isinstance(v, dict) and "value" in v:
-        return v["value"], v.get("qualifiers", {})
+        qualifiers = v.get("qualifiers")
+        return v["value"], qualifiers if isinstance(qualifiers, dict) else {}
     return v, {}
 
 
@@ -703,9 +705,11 @@ def update_item_sync(
             for v in values_list:
                 actual_val, qualifiers_dict = _parse_claim_value(v)
                 qualifiers = [api.get_claim(q_pid, q_val) for q_pid, q_val in qualifiers_dict.items()]
-                if actual_val in existing_by_value:
+                if actual_val in existing_by_value and not qualifiers:
+                    # No qualifier update — keep the existing claim as-is.
                     existing_by_value[actual_val].removed = False
                 else:
+                    # New value, or same value with qualifier changes — add fresh claim.
                     item.add_claim(norm_pid, actual_val, **({"qualifiers": qualifiers} if qualifiers else {}))
         else:
             for v in values_list:

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -362,7 +362,7 @@ class TestFlaskApp(unittest.TestCase):
         self.assertEqual(response["status"], "success")
         mock_item.labels.set.assert_called_once_with(language="en", value="Test item")
         mock_item.descriptions.set.assert_called_once_with(language="en", value="A test")
-        mock_item.add_claim.assert_called_once_with("wdt:P31", "wd:Q5")
+        mock_item.add_claim.assert_called_once_with("P31", "wd:Q5")
 
     def test_create_item_write_failure(self) -> None:
         """Test item creation when write returns no ID."""

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -450,6 +450,13 @@ class TestImportService(unittest.TestCase):
         self.assertEqual(val2, "y_n")
         self.assertEqual(qualifiers2, {})
 
+    def test_parse_claim_value_dict_without_qualifiers_key_is_not_unwrapped(self) -> None:
+        """A dict with only 'value' (no 'qualifiers' key) is treated as the raw claim value."""
+        raw = {"value": "y_n"}
+        val, qualifiers = import_service._parse_claim_value(raw)
+        self.assertIs(val, raw)
+        self.assertEqual(qualifiers, {})
+
     def test_update_item_sync_item_not_found(self) -> None:
         """Return not_found status when api.item.get raises."""
         api = Mock()

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -419,12 +419,14 @@ class TestImportService(unittest.TestCase):
         """When overriding an existing value with qualifiers, the old claim is replaced."""
         old_claim = Mock()
         old_claim.mainsnak.datavalue = {"value": "y_n"}
+        old_claim.removed = False
+        old_claim.remove.side_effect = lambda: setattr(old_claim, "removed", True)
         api, item = self._make_mock_api(existing_claims=[old_claim])
         qualifier_claim = Mock()
         api.get_claim.return_value = qualifier_claim
 
         with patch("services.import_service.MardiClient", return_value=api):
-            payload, ok = import_service.update_item_sync(
+            _, ok = import_service.update_item_sync(
                 "Q1",
                 claims={"P983": {"value": "y_n", "qualifiers": {"P984": "Q12345"}}},
                 do_override=True,

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -440,6 +440,28 @@ class TestImportService(unittest.TestCase):
         self.assertTrue(old_claim.removed)
         item.add_claim.assert_called_once_with("P983", "y_n", qualifiers=[qualifier_claim])
 
+    def test_update_item_sync_override_explicit_empty_qualifiers_replaces_existing(self) -> None:
+        """Explicit empty-qualifiers object form forces a fresh claim even with no new qualifiers."""
+        old_claim = Mock()
+        old_claim.mainsnak.datavalue = {"value": "y_n"}
+        old_claim.removed = False
+        old_claim.remove.side_effect = lambda: setattr(old_claim, "removed", True)
+        api, item = self._make_mock_api(existing_claims=[old_claim])
+
+        with patch("services.import_service.MardiClient", return_value=api):
+            _, ok = import_service.update_item_sync(
+                "Q1",
+                claims={"P983": {"value": "y_n", "qualifiers": {}}},
+                do_override=True,
+                username="testuser",
+                password="testpass",
+            )
+
+        self.assertTrue(ok)
+        # old claim stays removed; a fresh qualifier-free claim is added
+        self.assertTrue(old_claim.removed)
+        item.add_claim.assert_called_once_with("P983", "y_n")
+
     def test_parse_claim_value_null_qualifiers_returns_empty_dict(self) -> None:
         """Non-dict qualifiers field (null, list) is normalised to empty dict."""
         val, qualifiers = import_service._parse_claim_value({"value": "y_n", "qualifiers": None})

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -415,6 +415,39 @@ class TestImportService(unittest.TestCase):
         api.get_claim.assert_called_once_with("P984", "Q12345")
         item.add_claim.assert_called_once_with("P983", "y_n", qualifiers=[qualifier_claim])
 
+    def test_update_item_sync_override_with_qualifier_replaces_existing(self) -> None:
+        """When overriding an existing value with qualifiers, the old claim is replaced."""
+        old_claim = Mock()
+        old_claim.mainsnak.datavalue = {"value": "y_n"}
+        api, item = self._make_mock_api(existing_claims=[old_claim])
+        qualifier_claim = Mock()
+        api.get_claim.return_value = qualifier_claim
+
+        with patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync(
+                "Q1",
+                claims={"P983": {"value": "y_n", "qualifiers": {"P984": "Q12345"}}},
+                do_override=True,
+                username="testuser",
+                password="testpass",
+            )
+
+        self.assertTrue(ok)
+        old_claim.remove.assert_called_once()
+        # existing claim must NOT be un-removed; a fresh claim with qualifier is added instead
+        self.assertTrue(old_claim.removed)
+        item.add_claim.assert_called_once_with("P983", "y_n", qualifiers=[qualifier_claim])
+
+    def test_parse_claim_value_null_qualifiers_returns_empty_dict(self) -> None:
+        """Non-dict qualifiers field (null, list) is normalised to empty dict."""
+        val, qualifiers = import_service._parse_claim_value({"value": "y_n", "qualifiers": None})
+        self.assertEqual(val, "y_n")
+        self.assertEqual(qualifiers, {})
+
+        val2, qualifiers2 = import_service._parse_claim_value({"value": "y_n", "qualifiers": ["bad"]})
+        self.assertEqual(val2, "y_n")
+        self.assertEqual(qualifiers2, {})
+
     def test_update_item_sync_item_not_found(self) -> None:
         """Return not_found status when api.item.get raises."""
         api = Mock()

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -374,6 +374,47 @@ class TestImportService(unittest.TestCase):
         self.assertFalse(old_claim.removed)
         item.add_claim.assert_called_once_with("P16", "Q99")
 
+    def test_create_item_sync_with_qualifier(self) -> None:
+        """Object-form claim value passes qualifier to add_claim."""
+        item = Mock()
+        result = Mock()
+        result.id = "Q42"
+        item.write.return_value = result
+        api = Mock()
+        api.item.new.return_value = item
+        qualifier_claim = Mock()
+        api.get_claim.return_value = qualifier_claim
+
+        with patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.create_item_sync(
+                "Test formula",
+                claims={"P983": {"value": "y_n", "qualifiers": {"P984": "Q12345"}}},
+                username="testuser",
+                password="testpass",
+            )
+
+        self.assertTrue(ok)
+        api.get_claim.assert_called_once_with("P984", "Q12345")
+        item.add_claim.assert_called_once_with("P983", "y_n", qualifiers=[qualifier_claim])
+
+    def test_update_item_sync_with_qualifier(self) -> None:
+        """Object-form claim value in update passes qualifier to add_claim."""
+        api, item = self._make_mock_api(existing_claims=None)
+        qualifier_claim = Mock()
+        api.get_claim.return_value = qualifier_claim
+
+        with patch("services.import_service.MardiClient", return_value=api):
+            payload, ok = import_service.update_item_sync(
+                "Q1",
+                claims={"P983": {"value": "y_n", "qualifiers": {"P984": "Q12345"}}},
+                username="testuser",
+                password="testpass",
+            )
+
+        self.assertTrue(ok)
+        api.get_claim.assert_called_once_with("P984", "Q12345")
+        item.add_claim.assert_called_once_with("P983", "y_n", qualifiers=[qualifier_claim])
+
     def test_update_item_sync_item_not_found(self) -> None:
         """Return not_found status when api.item.get raises."""
         api = Mock()

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -464,20 +464,23 @@ class TestImportService(unittest.TestCase):
 
     def test_parse_claim_value_null_qualifiers_returns_empty_dict(self) -> None:
         """Non-dict qualifiers field (null, list) is normalised to empty dict."""
-        val, qualifiers = import_service._parse_claim_value({"value": "y_n", "qualifiers": None})
+        val, qualifiers, explicit = import_service._parse_claim_value({"value": "y_n", "qualifiers": None})
         self.assertEqual(val, "y_n")
         self.assertEqual(qualifiers, {})
+        self.assertTrue(explicit)
 
-        val2, qualifiers2 = import_service._parse_claim_value({"value": "y_n", "qualifiers": ["bad"]})
+        val2, qualifiers2, explicit2 = import_service._parse_claim_value({"value": "y_n", "qualifiers": ["bad"]})
         self.assertEqual(val2, "y_n")
         self.assertEqual(qualifiers2, {})
+        self.assertTrue(explicit2)
 
     def test_parse_claim_value_dict_without_qualifiers_key_is_not_unwrapped(self) -> None:
         """A dict with only 'value' (no 'qualifiers' key) is treated as the raw claim value."""
         raw = {"value": "y_n"}
-        val, qualifiers = import_service._parse_claim_value(raw)
+        val, qualifiers, explicit = import_service._parse_claim_value(raw)
         self.assertIs(val, raw)
         self.assertEqual(qualifiers, {})
+        self.assertFalse(explicit)
 
     def test_update_item_sync_item_not_found(self) -> None:
         """Return not_found status when api.item.get raises."""


### PR DESCRIPTION
## Summary

- Adds `_parse_claim_value` helper that accepts either a bare scalar (`"Q123"`) or an object form (`{"value": "y_n", "qualifiers": {"P984": "Q12345"}}`) for claim values
- `create_item_sync` and `update_item_sync` now extract qualifiers from the object form and forward them to `item.add_claim` via `api.get_claim`
- Bare scalars and list-of-scalars paths are fully unchanged — backward compatible

## Motivation

Formula items in the MaRDI KG use P983 (symbol notation) with P984 qualifiers (symbol represents). Without this change the DOIP CLI can only create bare symbol strings with no semantic link to the concept they represent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sync-based claim imports now support optional qualifiers, resolving qualifier references and attaching them to imported claims.

* **Bug Fixes**
  * Claim updates with overrides now more reliably match and replace existing claims using normalized claim values, with correct qualifier handling.
  * Property identifiers are now normalized during sync for consistent claim formatting.

* **Tests**
  * Added unit tests covering qualifier parsing/empty qualifiers and create/update override behavior.
  * Updated test expectations to reflect normalized claim property ID formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->