### PR TITLE
add languages to cli

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -23,6 +23,15 @@ python -m cli.importer_cli import-wikidata-async --qids "Q42,Q1"
 python -m cli.importer_cli import-wikidata --qids Q42 Q1
 ```
 
+Restrict or widen the imported label/description/alias languages with
+`--languages` (comma-separated). `mul` is always included unless you pass
+`all`. When omitted, the default is `en,de,mul`.
+
+```bash
+python -m cli.importer_cli import-wikidata --qids Q42 --languages en,de,fr   # -> en,de,fr,mul
+python -m cli.importer_cli import-wikidata --qids Q42 --languages all        # every language
+```
+
 ### DOI import (async via Prefect)
 
 ```bash

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -220,6 +220,18 @@ def cmd_import_workflow_runs(_args: argparse.Namespace) -> int:
         print(json.dumps({"error": "prefect api error", "details": str(exc)}))
         return 1
 
+def _parse_languages(value: str | None):
+    if value is None:
+        return None
+    value = value.strip()
+    if value.lower() == "all":
+        return "all"
+    langs = [lang.strip() for lang in value.split(",") if lang.strip()]
+    if not langs:
+        return None
+    if "mul" not in langs:
+        langs.append("mul")
+    return langs
 
 def cmd_import_wikidata(args: argparse.Namespace) -> int:
     """Import Wikidata entities synchronously by QID.
@@ -235,7 +247,8 @@ def cmd_import_wikidata(args: argparse.Namespace) -> int:
         print(json.dumps({"error": "missing qids"}))
         return 2
 
-    payload, all_ok = import_wikidata_sync(qids)
+    languages = _parse_languages(args.languages)
+    payload, all_ok = import_wikidata_sync(qids,languages=languages)
     print(json.dumps(payload))
     return 0 if all_ok else 1
 
@@ -501,6 +514,12 @@ def build_parser() -> argparse.ArgumentParser:
     )
     sub.add_argument("--qids", nargs="*", help="QIDs list or comma-separated.")
     sub.set_defaults(func=cmd_import_wikidata)
+
+    sub.add_argument("--languages",
+        help='Comma-separated language codes to import (e.g. "en,de,fr"), '
+        'or "all" for every language. mul is always included unless "all". '
+        "Defaults to en,de,mul.",
+    )
 
     sub = subparsers.add_parser("import-doi-async", help="Trigger Prefect DOI import.")
     sub.add_argument("--dois", nargs="*", help="DOIs list or comma-separated.")

--- a/cli/importer_cli.py
+++ b/cli/importer_cli.py
@@ -226,7 +226,7 @@ def _parse_languages(value: str | None):
     value = value.strip()
     if value.lower() == "all":
         return "all"
-    langs = [lang.strip() for lang in value.split(",") if lang.strip()]
+    langs = [lang.strip().lower() for lang in value.split(",") if lang.strip()]
     if not langs:
         return None
     if "mul" not in langs:

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -42,6 +42,15 @@ Run synchronous imports::
   python -m cli.importer_cli import-doi --dois 10.1000/XYZ123
   python -m cli.importer_cli import-cran --packages dplyr ggplot2
 
+  The ``import-wikidata`` command accepts an optional ``--languages`` flag
+  (comma-separated language codes, or ``all``) to control which label,
+  description and alias languages are imported. ``mul`` is always included
+  unless ``all`` is given; the default when omitted is ``en,de,mul``. The flag
+  applies only to this synchronous command, not to ``import-wikidata-async``::
+
+  python -m cli.importer_cli import-wikidata --qids Q42 --languages en,de,fr
+  python -m cli.importer_cli import-wikidata --qids Q42 --languages all
+
 Create a knowledge graph item::
 
   # Typed format — schema fills predefined claims automatically

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -344,7 +344,7 @@ def trigger_doi_async(
     }
 
 
-def import_wikidata_sync(qids: list[str]) -> tuple[dict, bool]:
+def import_wikidata_sync(qids: list[str], languages=None) -> tuple[dict, bool]:
     """Import Wikidata entities synchronously.
 
     Args:
@@ -353,7 +353,10 @@ def import_wikidata_sync(qids: list[str]) -> tuple[dict, bool]:
     Returns:
         Tuple of payload and overall success flag.
     """
-    wdi = WikidataImporter()
+    if languages is None:
+        wdi = WikidataImporter()
+    else:
+        wdi = WikidataImporter(languages=languages)
     results: dict[str, dict] = {}
     all_ok = True
 

--- a/tests/test_import_service.py
+++ b/tests/test_import_service.py
@@ -212,6 +212,18 @@ class TestImportService(unittest.TestCase):
         self.assertEqual(payload["results"]["Q2"]["status"], "not_imported")
         self.assertEqual(payload["results"]["Q3"]["status"], "error")
 
+    def test_import_wikidata_sync_languages_forwarded(self) -> None:
+        importer = Mock()
+        importer.import_entities.return_value = "Q1"
+
+        with patch("services.import_service.WikidataImporter", return_value=importer) as wdi:
+            import_service.import_wikidata_sync(["Q1"], languages=["en", "mul"])
+        wdi.assert_called_once_with(languages=["en", "mul"])
+
+        with patch("services.import_service.WikidataImporter", return_value=importer) as wdi:
+            import_service.import_wikidata_sync(["Q1"])
+        wdi.assert_called_once_with()   # None -> default en/de/mul preserved
+
     def test_import_doi_sync(self) -> None:
         """Return per-DOI results and overall success flag."""
         arxiv_source = Mock()


### PR DESCRIPTION
add the option to use all languages in the wikidata sync import of the cli

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--languages` option for synchronous Wikidata imports to restrict or expand which label, description, and alias languages are imported (comma-separated codes or `all`).
  * `mul` is included automatically unless `all` is selected; default is `en,de,mul`. Applies to the synchronous command only.
* **Documentation**
  * Updated CLI docs and command help with the new flag, accepted values, and example invocations.
* **Bug Fixes**
  * Ensures the selected language set is consistently used during import execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->