### PR TITLE
fix overlong queries for references

### DIFF
--- a/mardi_importer/mardi_importer/zbmath/misc.py
+++ b/mardi_importer/mardi_importer/zbmath/misc.py
@@ -72,7 +72,12 @@ def deduplicate_arxiv_file(old_arxiv_path, new_arxiv_path):
     new_only.to_csv(dedup_path, sep="\t", index=False)
     return dedup_path
 
-def run_references(dump_path, mc, log, resume_after_de=None, progress_callback=None):
+
+def _chunked(seq, size):
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
+
+def run_references(dump_path, mc, log, resume_after_de=None, progress_callback=None,batch_size=100):
 
     df = pd.read_csv(dump_path, sep="\t")
     subset = df[~df.references.isna()]
@@ -85,10 +90,12 @@ def run_references(dump_path, mc, log, resume_after_de=None, progress_callback=N
             else:
                 resume_after_de = None
                 continue
-        references = row["references"].split(";")
+        references = [r for r in row["references"].split(";") if r]
         if not references:
             continue
-        mapping = mc.batch_search_by_value("P1451", references)
+        mapping = {}
+        for chunk in _chunked(references, batch_size):
+            mapping.update(mc.batch_search_by_value("P1451", chunk))
         ref_qids = [mapping[r][0] for r in references if mapping.get(r)]
 
         if ref_qids:


### PR DESCRIPTION
fix overlong queries for references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reference processing to ignore empty entries and skip rows without valid references.
  * Reduced failures and slowdowns when handling large reference lists by processing lookups in smaller batches.
  * Results are now combined consistently across all batches for more reliable matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->